### PR TITLE
fixing worker crash due to missing path expansion

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -177,6 +177,7 @@ class Worker(object):
         try:
             view = sublime.active_window().active_view()
             python = get_settings(view, 'python_interpreter', 'python')
+            python = os.path.expanduser(python)
         except:
             python = 'python'
 


### PR DESCRIPTION
Hi,

Anaconda was not working for me at all.
After a quick look at the console I realized my `python_interpreter` was causing issues:

```
ERROR:root:[Errno 2] No such file or directory: '~/workspace/yadtshell/venv/bin/python'
ERROR:root:Traceback (most recent call last):
  File "/data/home/max/.config/sublime-text-3/Packages/Anaconda/worker.py", line 72, in start
    self.start_json_server(worker['port'])
  File "/data/home/max/.config/sublime-text-3/Packages/Anaconda/worker.py", line 94, in start_json_server
    self.build_server(port)
  File "/data/home/max/.config/sublime-text-3/Packages/Anaconda/worker.py", line 188, in build_server
    self.json_server = subprocess.Popen(args, **kwargs)
  File "X/subprocess.py", line 818, in __init__
  File "X/subprocess.py", line 1416, in _execute_child
FileNotFoundError: [Errno 2] No such file or directory: '~/workspace/yadtshell/venv/bin/python'
```

I don't really want to hardcode the path to my home as it varies from machine to machine.
I added a statement for path expansion and it runs fine now. 

Regards,
max
