### PR TITLE
Import new AnacondaSetPythonInterpreter class

### DIFF
--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2013 - Oscar Campos <oscar.campos@member.fsf.org>
 # This program is Free Software see LICENSE file for details
 
@@ -13,6 +12,7 @@ from .enable_linting import AnacondaEnableLinting
 from .next_lint_error import AnacondaNextLintError
 from .disable_linting import AnacondaDisableLinting
 from .complete_func_args import AnacondaCompleteFuncargs
+from .set_python_interpreter import AnacondaSetPythonInterpreter
 from .vagrant import (
     AnacondaVagrantEnable, AnacondaVagrantInit, AnacondaVagrantStatus,
     AnacondaVagrantUp, AnacondaVagrantSsh


### PR DESCRIPTION
AnacondaSetPythonInterpreter is present in **all** list but not imported.

This is causing the plugin to not load correctly.

Error in Sublime console:

reloading plugin Anaconda.anaconda
Persisten list does not exists, skiping load...
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 73, in reload_plugin
    m = importlib.import_module(modulename)
  File "X/importlib/**init**.py", line 88, in import_module
  File "<frozen importlib._bootstrap>", line 1577, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1558, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1525, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 586, in _check_name_wrapper
  File "<frozen importlib._bootstrap>", line 1023, in load_module
  File "<frozen importlib._bootstrap>", line 1004, in load_module
  File "<frozen importlib._bootstrap>", line 562, in module_for_loader_wrapper
  File "<frozen importlib._bootstrap>", line 869, in _load_module
  File "<frozen importlib._bootstrap>", line 313, in _call_with_frames_removed
  File "/Users/hustoi/Library/Application Support/Sublime Text 3/Packages/Anaconda/anaconda.py", line 19, in <module>
    from .commands import *
AttributeError: 'module' object has no attribute 'AnacondaSetPythonInterpreter'
