### PR TITLE
Adding decorators to first line detection

### DIFF
--- a/commands/autoimport.py
+++ b/commands/autoimport.py
@@ -43,7 +43,7 @@ class AnacondaAutoImport(sublime_plugin.TextCommand):
 
     def _guess_insertion_line(self):
         view_code = self.view.substr(sublime.Region(0, self.view.size()))
-        match = re.search(r'^(def|class)\s+', view_code, re.M)
+        match = re.search(r'^(@.+|def|class)\s+', view_code, re.M)
         if match is not None:
             code = view_code[:match.start()]
             print(code)


### PR DESCRIPTION
The auto importer will add the import like this if there is a decorator 

```

from bla import bla
import bla 


@get("/")
                            <---------- Imports goes here but this pull request makes it go above the decorator
def method():
wefwefwef
```
