### PR TITLE
Fix issue with ignore_pyflakes not working.

### DIFF
--- a/anaconda_lib/linting/linter.py
+++ b/anaconda_lib/linting/linter.py
@@ -160,14 +160,7 @@ class Linter(object):
             return [PythonError(filename, FakeLoc(), error.args[0])]
         else:
             # the file is syntactically valid, check it now
-            if ignore is not None:
-                _magic_globals = pyflakes._MAGIC_GLOBALS
-                pyflakes._MAGIC_GLOBALS += ignore
-
-            w = pyflakes.Checker(tree, filename)
-
-            if ignore is not None:
-                pyflakes._MAGIC_GLOBALS = _magic_globals
+            w = pyflakes.Checker(tree, filename, ignore)
 
             return w.messages
 


### PR DESCRIPTION
As far as I can tell this might have been broken by some refactoring in Checker, but I haven't really looked at the history too closely. 

Essentially it was attempted to update a variable that bottomed out in a static class variable in Checker, so the update wasn't taking.  Thankfully Checker instead has an easy way to solve this by passing our ignore values to the builtins argument, so twas an easy fix.
