### PR TITLE
next_lint_error only returns the first lint error in the file

### DIFF
--- a/commands/next_lint_error.py
+++ b/commands/next_lint_error.py
@@ -6,17 +6,15 @@ import sublime
 import sublime_plugin
 
 from ..anaconda_lib.helpers import get_settings
-from ..anaconda_lib.linting.sublime import ANACONDA
-
+from ..anaconda_lib.linting.sublime import ANACONDA, update_statusbar
 
 class AnacondaNextLintError(sublime_plugin.WindowCommand):
-    """Jump to the next lint error on the list
+    """Jump to the next lint error on the page
     """
-
-    current_error = None
 
     def run(self):
         self.jump(self._harvest_next())
+        update_statusbar(self.window.active_view())
 
     def is_enabled(self):
         """Determines if the command is enabled
@@ -43,21 +41,23 @@ class AnacondaNextLintError(sublime_plugin.WindowCommand):
         self.window.active_view().sel().clear()
         self.window.active_view().sel().add(sublime.Region(pt))
 
-        self.window.active_view().show(pt)
+        self.window.active_view().show_at_center(pt)
 
     def _harvest_next(self):
         """Harvest the next error that we find and return it back
         """
 
-        klass = AnacondaNextLintError
+        (cur_line, cur_col) = self.window.active_view().rowcol(
+            self.window.active_view().sel()[0].begin()
+        )
         lines = set([])
         vid = self.window.active_view().id()
         for error_type in ['ERRORS', 'WARNINGS', 'VIOLATIONS']:
             for line, _ in ANACONDA[error_type].get(vid, {}).items():
                 lines.add(int(line))
-        lines = list(lines)
-        if (klass.current_error and lines[-1] > klass.current_error):
-            lines = [l for l in lines if l > klass.current_error]
-        klass.current_error = lines[0]
+        lines = sorted(list(lines))
+        if not len(lines):
+            return None
+        if (cur_line and lines[-1] > cur_line):
+            lines = [l for l in lines if l > cur_line]
         return lines[0]
-


### PR DESCRIPTION
Every time the anaconda_next_lint_error command is run it returns the first error it finds. If you've already found an error through this command it should take you to the next one.  This patch fixes that.
