### PR TITLE
Adding Autoformat PEP8 Shortcut Key

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -2,6 +2,7 @@
     {"command": "anaconda_goto", "keys": ["super+g"]},
     {"command": "anaconda_find_usages", "keys": ["super+f"]},
     {"command": "anaconda_doc", "keys": ["super+d"]},
+    {"command": "anaconda_auto_format", "keys": ["super+r"]},
     {"command": "anaconda_goto", "keys": ["g", "d"],
         "context":
         [

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,6 +2,7 @@
     {"command": "anaconda_goto", "keys": ["ctrl+alt+g"]},
     {"command": "anaconda_find_usages", "keys": ["ctrl+alt+f"]},
     {"command": "anaconda_doc", "keys": ["ctrl+alt+d"]},
+    {"command": "anaconda_auto_format", "keys": ["ctrl+alt+r"]},
     {"command": "anaconda_goto", "keys": ["g", "d"],
         "context":
         [

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -2,6 +2,7 @@
     {"command": "anaconda_goto", "keys": ["ctrl+alt+g"]},
     {"command": "anaconda_find_usages", "keys": ["ctrl+alt+f"]},
     {"command": "anaconda_doc", "keys": ["ctrl+alt+d"]},
+    {"command": "anaconda_auto_format", "keys": ["ctrl+alt+r"]},
     {"command": "anaconda_goto", "keys": ["g", "d"],
         "context":
         [

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ Anaconda can fix the following [PEP8 errors](https://github.com/DamnWidget/anaco
 
 Please, take a look at the configuration file to get a list of available options.
 
+* Shortcut: Linux `super+r`, Mac OS X and Windows `ctrl+alt+r`
+* Context Menu: `Anaconda > Autoformat PEP8 Errors`
+
 #### Autoimport undefined names
 
 Anaconda will add an `import <undefined_name>` at the end of your imports block if you use the context menu Autoimport anaconda option using the right mouse click over an undefined name in your buffer. Note that anaconda will NOT check if that is a valid import or not.


### PR DESCRIPTION
Adding Autoformat PEP8 Shortcut Key

Also I think its better to unify the Linux, Windows and OSX Keys
For eg: ["super+f"] in ubuntu is used to show up unity Find Menu
