### PR TITLE
Reduce the timeout so that we don't spend too much time looking for a jsonserver that is not running

### DIFF
--- a/anaconda_lib/worker.py
+++ b/anaconda_lib/worker.py
@@ -76,9 +76,11 @@ class BaseWorker(object):
 
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.settimeout(0.5)
+            s.settimeout(0.05)
             s.connect((self.hostaddr, self.available_port))
             s.close()
+        except socket.timeout:
+            return False
         except socket.error as error:
             if error.errno == errno.ECONNREFUSED:
                 return False


### PR DESCRIPTION
No more annoying delay when opening a Python file for the first time.
