### PR TITLE
Removing unnecessary check that is preventing interpreter switch

### DIFF
--- a/anaconda_lib/decorators.py
+++ b/anaconda_lib/decorators.py
@@ -37,7 +37,6 @@ def auto_project_switch(func):
         if not self.green_light:
             return
 
-        wid = sublime.active_window().id()
         view = sublime.active_window().active_view()
         auto_project_switch = get_settings(view, 'auto_project_switch', False)
         python_interpreter = get_settings(view, 'python_interpreter')
@@ -45,8 +44,7 @@ def auto_project_switch(func):
             python_interpreter = python_interpreter.replace(
                 '$VIRTUAL_ENV', os.environ.get('VIRTUAL_ENV', 'python'))
         if (
-            auto_project_switch and hasattr(self, 'project_name') and
-            self.project_name != 'anaconda-{id}'.format(id=wid) and (
+            auto_project_switch and hasattr(self, 'project_name') and (
                 project_name() != self.project_name
                 or self.process.args[0] != python_interpreter)
         ):


### PR DESCRIPTION
It seems like `auto_project_switch` is broken if you ever open up a non-project file. Once a worker with a project name `"anaconda-{wid}"` is opened, the project switch detection never kicks in. I removed a check in the `if` clause that seemed unnecessary. Do you recall the reasoning behind this check?
