### PR TITLE
Use command name method instead of hardcoded string.

### DIFF
--- a/commands/doc.py
+++ b/commands/doc.py
@@ -44,7 +44,7 @@ class AnacondaDoc(sublime_plugin.TextCommand):
             if self.documentation is None or self.documentation == '':
                 self._show_status()
             else:
-                sublime.active_window().run_command('anaconda_doc')
+                sublime.active_window().run_command(self.name())
         else:
             self._show_status()
 


### PR DESCRIPTION
I want to read documentation on a second display (in terminal, tail -f /path/to/file), instead of displaying it in a tiny ST panel.
At first I thought it's better to modify existing Anaconda command, but decided to subclass into a separate command.
I still would like to see a small change in the original code, so that prepare_data calls my subclass, when documentation is found.
