### PR TITLE
Weird autocomplete behavior with function parameters

### DIFF
--- a/anaconda_server/commands/autocomplete.py
+++ b/anaconda_server/commands/autocomplete.py
@@ -5,7 +5,7 @@
 import logging
 import traceback
 
-from .base import Command, get_function_parameters
+from .base import Command
 
 DEBUG_MODE = False
 
@@ -23,14 +23,10 @@ class AutoComplete(Command):
         """
 
         try:
-            data = self._parameters_for_complete()
             completions = self.script.completions()
             if DEBUG_MODE is True:
                 logging.info(completions)
-            data.extend([
-                ('{0}\t{1}'.format(comp.name, comp.type), comp.name)
-                for comp in completions
-            ])
+            data = [('{0}\t{1}'.format(comp.name, comp.type), comp.name) for comp in completions]
             self.callback({
                 'success': True, 'completions': data, 'uid': self.uid
             })
@@ -43,31 +39,3 @@ class AutoComplete(Command):
             self.callback({
                 'success': False, 'error': str(error), 'uid': self.uid
             })
-
-    def _parameters_for_complete(self):
-        """Get function / class constructor paremeters completions list
-        """
-
-        completions = []
-        try:
-            in_call = self.script.call_signatures()[0]
-        except IndexError:
-            in_call = None
-
-        parameters = get_function_parameters(in_call)
-
-        for parameter in parameters:
-            try:
-                name, value = parameter
-            except ValueError:
-                name = parameter[0]
-                value = None
-
-            if value is None:
-                completions.append((name, '${1:%s}' % name))
-            else:
-                completions.append(
-                    (name + '\t' + value, '%s=${1:%s}' % (name, value))
-                )
-
-        return completions


### PR DESCRIPTION
For the following Python code:

``` python
def foo(fizz, buzz):
    pass

foo(f
```

the completions I get when I type `f` are the following:

![completions](https://cloud.githubusercontent.com/assets/2167984/3485283/302da290-03d1-11e4-8ea2-8099c1c470f9.png)

As you can see, I get two instances of `fizz`. I specified `suppress_word_completions` as `true`, so it is not due to that. The problem with the first one (the one that is not marked as `param`) is that if I select it and commit it using tab, the text gets selected. This is annoying because if I keep typing, it will overwrite the text.

![committed](https://cloud.githubusercontent.com/assets/2167984/3485298/ba73b2f0-03d1-11e4-9da3-0d32e7308d65.png)

This doesn't happen if I select the `param` entry.

I dug into the code a little bit and it looks like this is because Anaconda composes the autocomplete list from two things: [the completions as returned by Jedi](https://github.com/DamnWidget/anaconda/blob/master/anaconda_server/commands/autocomplete.py#L27), and the [parameters for the current function call](https://github.com/DamnWidget/anaconda/blob/master/anaconda_server/commands/autocomplete.py#L26) (if applicable). However, it looks like Jedi already returns the parameters when you request the completions, so maybe the additional logic to add parameters is unnecessary.
