### PR TITLE
enhanced support for shell variables in the python_interpreter setting

### DIFF
--- a/anaconda_lib/decorators.py
+++ b/anaconda_lib/decorators.py
@@ -40,9 +40,13 @@ def auto_project_switch(func):
         view = sublime.active_window().active_view()
         auto_project_switch = get_settings(view, 'auto_project_switch', False)
         python_interpreter = get_settings(view, 'python_interpreter')
-        if '$VIRTUAL_ENV' in python_interpreter:
-            python_interpreter = python_interpreter.replace(
-                '$VIRTUAL_ENV', os.environ.get('VIRTUAL_ENV', 'python'))
+
+        # expand ~/ in the python_interpreter path
+        python_interpreter = os.path.expanduser(python_interpreter)
+        
+        # expand $shell vars in the python_interpreter path
+        python_interpreter = os.path.expandvars(python_interpreter)
+
         if (
             auto_project_switch and hasattr(self, 'project_name') and (
                 project_name() != self.project_name


### PR DESCRIPTION
use os.path.expanduser and os.path.expandvars to support python_interpreter settings such as:
- "~/.virtualenv/whatever/bin/python"
- "$USER/.virtualenv/whatever/bin/python"
- "$VIRTUAL_ENV/.virtualenv/whatever/bin/python"
- "${whatever}/.virtualenv/whatever/bin/python"
