### PR TITLE
Regular expression to capture error output of cmd

### DIFF
--- a/templates/python_build.tpl
+++ b/templates/python_build.tpl
@@ -1,5 +1,6 @@
 {
     "name": "Anaconda Python Builder",
     "shell_cmd": "${python_interpreter} -u \"$file\"",
+    "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
     "selector": "source.python"
 }


### PR DESCRIPTION
Adding "file_regex" key to anaconda python builder. So a regular expression capture error output of cmd.
