### PR TITLE
E309 is now not being thrown if class docstring has no blank line above it

### DIFF
--- a/anaconda_lib/autopep/autopep8_lib/autopep8.py
+++ b/anaconda_lib/autopep/autopep8_lib/autopep8.py
@@ -152,10 +152,7 @@ def extended_blank_lines(logical_line,
                          previous_logical):
     """Check for missing blank lines after class declaration."""
     if previous_logical.startswith('class '):
-        if (
-            logical_line.startswith(('def ', 'class ', '@')) or
-            pep8.DOCSTRING_REGEX.match(logical_line)
-        ):
+        if logical_line.startswith(('def ', 'class ', '@')):
             if indent_level and not blank_lines:
                 yield (0, 'E309 expected 1 blank line after class declaration')
     elif previous_logical.startswith('def '):


### PR DESCRIPTION
That is not an error due to recent changes.
https://hg.python.org/peps/rev/9b715d8246db
