### PR TITLE
fixup: run server in project directory. Allows relative rcfile path #73

### DIFF
--- a/anaconda_lib/worker.py
+++ b/anaconda_lib/worker.py
@@ -253,7 +253,10 @@ class LocalWorker(BaseWorker):
             args.extend(['-e', ','.join(paths)])
 
         args.extend([str(os.getpid())])
-        self.process = create_subprocess(args)
+        kwargs = {}
+        if len(sublime.active_window().folders()) > 0:
+            kwargs['cwd'] = sublime.active_window().folders()[0]
+        self.process = create_subprocess(args, **kwargs)
         if self.process is None:
             # we can't spawn a new process for jsonserver. Wrong config?
             self.green_light = False


### PR DESCRIPTION
Currently only absolute path for rcfile is supported. With these changes it's possible to specify project related rcfile.

```
{
  "pylint_rcfile": "pylintrc"
}
```