### PR TITLE
callback should not be called when it is None, if on_failure is not spec...

### DIFF
--- a/anaconda_lib/callback.py
+++ b/anaconda_lib/callback.py
@@ -216,4 +216,4 @@ class Callback(object):
             )
 
         callback = self.callbacks.get(self._status.value, _panic)
-        return callback(*args, **kwargs)
+        return callback and callback(*args, **kwargs)


### PR DESCRIPTION
callback should not be called when it is None, if on_failure is not specified.
Sometimes there are many errors shown in the console log, eg, while finding usages failed.