### PR TITLE
Linting icon path fixed

### DIFF
--- a/anaconda_lib/linting/sublime.py
+++ b/anaconda_lib/linting/sublime.py
@@ -209,7 +209,7 @@ def add_lint_marks(view, lines, **errors):
         package_name = os.path.dirname(__file__).rsplit(os.path.sep, 3)[1]
         ico_path = (
             'Packages/' + package_name + '/anaconda_lib/linting/'
-            '/gutter_mark_themes/{theme}-{type}.png'
+            'gutter_mark_themes/{theme}-{type}.png'
         )
 
         for lint_type, lints in get_outlines(view).items():


### PR DESCRIPTION
The linting icon path contains double slash 
eg:
 Packages/Anaconda/anaconda_lib/linting//gutter_mark_themes/'

replaced it with:
Packages/Anaconda/anaconda_lib/linting/gutter_mark_themes/'
