### PR TITLE
removed vintage keybinding, fixes #373

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -2,13 +2,5 @@
     {"command": "anaconda_goto", "keys": ["super+g"]},
     {"command": "anaconda_find_usages", "keys": ["super+f"]},
     {"command": "anaconda_doc", "keys": ["super+d"]},
-    {"command": "anaconda_auto_format", "keys": ["super+r"]},
-    {"command": "anaconda_goto", "keys": ["g", "d"],
-        "context":
-        [
-            { "key": "selector", "operator": "equal", "operand": "source.python" },
-            { "key": "setting.command_mode", "operand": true },
-            { "key": "setting.is_widget", "operand": false }
-        ]
-    }
+    {"command": "anaconda_auto_format", "keys": ["super+r"]}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -3,14 +3,6 @@
     {"command": "anaconda_find_usages", "keys": ["ctrl+alt+f"]},
     {"command": "anaconda_doc", "keys": ["ctrl+alt+d"]},
     {"command": "anaconda_auto_format", "keys": ["ctrl+alt+r"]},
-    {"command": "anaconda_goto", "keys": ["g", "d"],
-        "context":
-        [
-            { "key": "selector", "operator": "equal", "operand": "source.python" },
-            { "key": "setting.command_mode", "operand": true },
-            { "key": "setting.is_widget", "operand": false }
-        ]
-    },
     {"command": "anaconda_run_current_file_tests", "keys": ["ctrl+alt+t"]},
     {"command": "anaconda_run_current_test", "keys": ["ctrl+alt+shift+t"]}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -2,13 +2,5 @@
     {"command": "anaconda_goto", "keys": ["ctrl+alt+g"]},
     {"command": "anaconda_find_usages", "keys": ["ctrl+alt+f"]},
     {"command": "anaconda_doc", "keys": ["ctrl+alt+d"]},
-    {"command": "anaconda_auto_format", "keys": ["ctrl+alt+r"]},
-    {"command": "anaconda_goto", "keys": ["g", "d"],
-        "context":
-        [
-            { "key": "selector", "operator": "equal", "operand": "source.python" },
-            { "key": "setting.command_mode", "operand": true },
-            { "key": "setting.is_widget", "operand": false }
-        ]
-    }
+    {"command": "anaconda_auto_format", "keys": ["ctrl+alt+r"]}
 ]


### PR DESCRIPTION
Removed the keymap problem explained in https://github.com/DamnWidget/anaconda/issues/373. 

If a user wants this behavior, he can just add the keybinding himself but I'm pretty sure keeping this will confuse a bunch of vintage users (me included) in why suddenly some keys work differently. Especially with a lot of packages installed finding the source of this problem was quite tricky