### PR TITLE
html constructor arg default to None

### DIFF
--- a/anaconda_server/commands/doc.py
+++ b/anaconda_server/commands/doc.py
@@ -11,7 +11,7 @@ class Doc(Command):
     """Get back a python definition where to go
     """
 
-    def __init__(self, callback, uid, script, html):
+    def __init__(self, callback, uid, script, html=None):
         self.script = script
         self.html = html
         super(Doc, self).__init__(callback, uid)


### PR DESCRIPTION
Using the vagrant_server branch, running `python server.py`, will constantly throw the following error:

  error: uncaptured python exception, closing channel <__main__.JSONHandler connected 192.168.59.3:60400 at 0x7f40f1212dd8> (<class 'TypeError'>:__init__() missing 1 required positional argument: 'html' [/usr/local/lib/python3.4/asyncore.py|read|83] [/usr/local/lib/python3.4/asyncore.py|handle_read_event|442] [/usr/local/lib/python3.4/asynchat.py|handle_read|171] [../anaconda_server/jsonserver.py|found_terminator|93] [../anaconda_server/jsonserver.py|handle_command|111] [/anaconda/anaconda_server/handlers/jedi_handler.py|run|30] [/anaconda/anaconda_server/lib/anaconda_handler.py|run|48] [/anaconda/anaconda_server/handlers/jedi_handler.py|doc|98])

This occurs when the sublime user changes any text in a python file.