### PR TITLE
Fix for #412

### DIFF
--- a/listeners/signatures.py
+++ b/listeners/signatures.py
@@ -55,13 +55,15 @@ class AnacondaSignaturesEventListener(sublime_plugin.EventListener):
         show_tooltip = get_settings(view, 'enable_signatures_tooltip', True)
         show_doc = get_settings(view, 'merge_signatures_and_doc', True)
         if data['success'] and 'No docstring' not in data['doc']:
+            i = data['doc'].split('<br>').index("")
             if show_tooltip and show_doc and st_version >= 3070:
-                self.doc = '<br>'.join(data['doc'].split('<br>')[2:])
+                self.doc = '<br>'.join(data['doc'].split('<br>')[i:])
 
             if not show_tooltip or st_version < 3070:
                 self.signature = data['doc'].splitlines()[2]
             else:
-                self.signature = data['doc'].split('<br>')[0]
+                self.signature = '<br>&nbsp;&nbsp;&nbsp;&nbsp;'.join(
+                    data['doc'].split('<br>')[0:i])
             if ('(' in self.signature and
                     self.signature.split('(')[0].strip() not in self.exclude):
                 if self.signature is not None and self.signature != '':


### PR DESCRIPTION
First of all, I'm new to this so I don't know whether I need to wait for someone to approve to create a pull request on the issue I reported. So apologies for not following protocol that I might be unaware of.

This would make it look like so:
<img width="635" alt="screen shot 2015-12-27 at 12 33 15 am" src="https://cloud.githubusercontent.com/assets/3027195/12008959/85ced08e-ac31-11e5-9790-32e89528370c.png">

Instead of so:
<img width="636" alt="screen shot 2015-12-27 at 12 26 06 am" src="https://cloud.githubusercontent.com/assets/3027195/12008961/9aa45cd6-ac31-11e5-8f5d-64fd83c516b9.png">

Notice that the second line of signature was completely absent from the popup, making this not just a formatting issue.