### PR TITLE
Escape Python Interpretter by default in build system

### DIFF
--- a/templates/python_build.tpl
+++ b/templates/python_build.tpl
@@ -1,6 +1,6 @@
 {
     "name": "Anaconda Python Builder",
-    "shell_cmd": "${python_interpreter} -u \"$file\"",
+    "shell_cmd": "\"${python_interpreter}\" -u \"$file\"",
     "file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
     "selector": "source.python"
 }


### PR DESCRIPTION
Resolves and fixes #421.