### PR TITLE
Fix for #434 - autoimport fails when no def or class definition

### DIFF
--- a/commands/autoimport.py
+++ b/commands/autoimport.py
@@ -46,6 +46,11 @@ class AnacondaAutoImport(sublime_plugin.TextCommand):
         match = re.search(r'^(@.+|def|class)\s+', view_code, re.M)
         if match is not None:
             code = view_code[:match.start()]
+        else:
+            # No class or function definition in this file, search for existing
+            # import
+            match = re.search(r'\s+.* tropmi', view_code[::-1], re.M)
+            code = view_code[:len(view_code) - match.start()]
 
         return len(code.split('\n')) - 1
 


### PR DESCRIPTION
If there is no def or class definition, then try to look for an import statement and place the new autoimort rigth after. #Fixes #434