### PR TITLE
Bugfix: Additional py.test support for Test Runner

### DIFF
--- a/Anaconda.sublime-settings
+++ b/Anaconda.sublime-settings
@@ -512,6 +512,15 @@
     /* This is the delimiter between the module and the class */
     "test_delimeter": ":",
 
+    /* This is the delimiter between the class and the method */
+    "test_method_delimeter": ".",
+
+    /*
+        Uncomment the line below to enable filepath-based test runner
+        patterns like those required for py.test.
+    */
+    // "test_filepath_patterns": true,
+
     /* Uncomment the line below to use a virtualenv for your tests */
     //"test_virtualenv": ""
 


### PR DESCRIPTION
Hello, I ran into some issues with the test runner and py.test's requirements for specifying test paths, so I've whipped up a quick fix. I hope it's useful!

py.test requires the following format when specifying targeted tests:

> py.test path/to/file.py::ModuleName::test_name

Because of this, the `Run Current Test` and `Run Current File Tests` commands
produced test paths that were incompatible with py.test.

This commit adds:

- a `test_filepath_patterns` setting that tells the Test Runner
to use filepaths when building test pattern paths.

- an additional delimeter setting named `test_method_delimeter` that allows
the user to specify the delimeter to be used to separate the targeted class
and method.

Recommended settings for py.test users:
- test_delimeter: "::"
- test_method_delimeter: "::"
- test_filepath_patterns: true