### PR TITLE
Fix tooltips for function signatures and docstrings which contain special HTML characters. Fixes #417

### DIFF
--- a/anaconda_server/commands/doc.py
+++ b/anaconda_server/commands/doc.py
@@ -3,6 +3,7 @@
 # This program is Free Software see LICENSE file for details
 
 import logging
+import html
 
 from .base import Command
 
@@ -58,6 +59,7 @@ class Doc(Command):
     def _html(self, definition):
         """Generate documentation string in HTML format
         """
+        escaped_doc = html.escape(html.unescape(definition.doc), quote=False)
+        escaped_doc = escaped_doc.replace('\n', '<br>')
 
-        return '{0}\n{1}'.format(
-            definition.full_name, definition.doc.replace('\n', '<br>'))
+        return '{0}\n{1}'.format(definition.full_name, escaped_doc)

--- a/listeners/signatures.py
+++ b/listeners/signatures.py
@@ -60,12 +60,14 @@ class AnacondaSignaturesEventListener(sublime_plugin.EventListener):
                 i = data['doc'].split('<br>').index("")
             except ValueError:
                 self.signature = data['doc']
+                self.doc = ''
                 if show_tooltip and show_doc and st_version >= 3070:
                     return self._show_popup(view)
                 return self._show_status(view)
 
             if show_tooltip and show_doc and st_version >= 3070:
                 self.doc = '<br>'.join(data['doc'].split('<br>')[i:])
+                self.doc = self.doc.replace("  ", "&nbsp;&nbsp;")
 
             if not show_tooltip or st_version < 3070:
                 self.signature = data['doc'].splitlines()[2]


### PR DESCRIPTION
Hi,

I've been using Anaconda for a while (thanks!), so figured I'd try and help out with some fixing. This is my first pull request, so let me know if I've done anything wrong :)

---

I started reading the developer's book [here](https://www.gitbook.com/book/damnwidget/anacondast3-developers-documentation/details).

The section there 'The Development Workflow' mentions _Make sure that you add an entry about the new fix/feature that you introduced into anaconda in the relnotes index_ with a link to:
https://github.com/DamnWidget/anaconda/blob/master/templates/relnotes.tpl
which gives a 404, so I've not done whatever that was meant to cover.

I kept reading and came to another dead link when I got to unit testing:
https://damnwidget.gitbooks.io/using_github/README.html#anacondas-development-project-configuration
So sort of gave up with this at that point - sorry.

---

Anyway, I found a good test case for this problem was:

```py
import unittest

class TestBasic(unittest.TestCase):
    def test_basic(self):

        self.assertLogs       # This has a single quote "'"
        self.assertLessEqual  # This has a '<' in it
```

The bug seems to be that tooltips don't handle `<` characters properly. You would think that just html escaping the whole string would be the right solution, but it turns out that the Sublime tooltips don't seem to like some escaped characters - this appears in the Sublime console:

```html
Parse Error: #x27;foo&#x27;, level=&#x27;INFO&#x27;) as cm:<br>        logging.getLogger(&#x27;foo&#x27;).info(&#x27;first message&#x27;)<br>        logging.getLogger(&#x27;foo.bar&#x27;).error(&#x27;second message&#x27;)<br>    self.assertEqual(cm.output, [&#x27;INFO:foo:first message&#x27;,<br>                                 &#x27;ERROR:foo.bar:second message&#x27;])</p>
</div>
 code: Unexpected character
```

That's an escaped `'` that seems to have come from Jedi, and luckily Python's `html.escape` has an option to skip escaping quotes, so first unescaping the string, then re-escaping it again skipping quotes seems to be the right fix.

That seems to fix the problems with Anaconda hitting errors when displaying docstrings, but if you look at the docstring for `assertLessEqual` above, it should also have indentation on some lines which is lost.

Whitespace is combined down in HTML, but we can work around it by replacing every pair of spaces with non-breaking spaces so they are preserved. It looks like the docsting is prepared for display in `signatures.py`, so I replaced each pair of spaces with no-breaking ones there.

As a more rigorous test, I checked that we can safely display this docstring:

**(Warning - This completely crashed Sublime when Anaconda tries to show the signature for this class for me before the fix!)**

```py
class BadDocstring:
    """!"£$%^&*()/*-<>?:@~{}|\`¬,./;'#[]-=_+"""
```

At this point it still didn't display quite right in the 'signature' popup - the docstring shown is the one from the *last* signature popup that Anaconda generated. It was now fine in the `Show Documentation` command in the right-click context menu though.

The problem here was just `self.doc` not being reset if the docstring was small enough, which is the first fix in `signatures.py`.

I've tested the changes with a bunch of docstrings, in both the signature tooltip popup and the `Show Documentation` command in the right-click context menu, and now everything seems to work fine.

I still think that `Anaconda/listeners/signatures.py` `AnacondaSignaturesEventListener.prepare_data` needs some tidying up as I can't really understand what's going on there - however, I didn't want to start messing around with this too much because I seemed to change one thing and break another, and this seems like a pretty self-contained fix as-is.

Thanks.