### PR TITLE
Fix excluding signatures for numbers and constants like 'True'. Fixes #416

### DIFF
--- a/listeners/signatures.py
+++ b/listeners/signatures.py
@@ -20,7 +20,7 @@ class AnacondaSignaturesEventListener(sublime_plugin.EventListener):
     doc = None
     signature = None
     exclude = (
-        'None', 'str', 'int', 'float', 'True',
+        'None', 'NoneType', 'str', 'int', 'float', 'True',
         'False', 'in', 'or', 'and', 'bool'
     )
 
@@ -61,6 +61,8 @@ class AnacondaSignaturesEventListener(sublime_plugin.EventListener):
             except ValueError:
                 self.signature = data['doc']
                 self.doc = ''
+                if self._signature_excluded(self.signature):
+                    return
                 if show_tooltip and show_doc and st_version >= 3070:
                     return self._show_popup(view)
                 return self._show_status(view)
@@ -74,9 +76,8 @@ class AnacondaSignaturesEventListener(sublime_plugin.EventListener):
             else:
                 self.signature = '<br>&nbsp;&nbsp;&nbsp;&nbsp;'.join(
                     data['doc'].split('<br>')[0:i])
-            if ('(' in self.signature and
-                    self.signature.split('(')[0].strip() not in self.exclude):
-                if self.signature is not None and self.signature != '':
+            if self.signature is not None and self.signature != '':
+                if not self._signature_excluded(self.signature):
                     if show_tooltip:
                         return self._show_popup(view)
 
@@ -109,3 +110,13 @@ class AnacondaSignaturesEventListener(sublime_plugin.EventListener):
         view.set_status(
             'anaconda_doc', 'Anaconda: {}'.format(self.signature)
         )
+
+    def _signature_excluded(self, signature):
+        """Whether to supress displaying information for the given signature.
+        """
+
+        # Check for the empty string first so the indexing in the next tests
+        # can't hit an exception, and we don't want to show an empty signature.
+        return ((signature == "") or
+                (signature.split('(', 1)[0].strip() in self.exclude) or
+                (signature.lstrip().split(None, 1)[0] in self.exclude))


### PR DESCRIPTION
Hi,

Thanks for taking my last fix. Here's another small fix, this time for issue #416.

Specific changes:

* Typing Python's `None` displays the signature `NoneType` for me, so exclude that.
* Clean up the checking for excluded signatures and move it to a helper method. The checking didn't work for me, because for example the signature for `int` was of the format `int int(...`, so as well as splitting on `(` also split on whitespace to get the name.

Tested by checking that signatures are not shown for each of the `exclude`s by typing:

```py
str()
bool()
False and True
None and False
int
1234
1.2354
```

But are for a few other things like:

```py
tuple()
list()
input
```
