### PR TITLE
Implement prev_lint_error command

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -29,6 +29,10 @@
                 "caption": "Next lint error"
             },
             {
+                "command": "anaconda_prev_lint_error",
+                "caption": "Previous lint error"
+            },
+            {
                 "command": "anaconda_auto_format",
                 "caption": "Autoformat PEP8 Errors"
             },

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -16,6 +16,10 @@
         "command": "anaconda_next_lint_error"
     },
     {
+        "caption": "Anaconda: Previous lint error",
+        "command": "anaconda_prev_lint_error"
+    },
+    {
         "caption": "Anaconda: Autoformat PEP8 Errors",
         "command": "anaconda_auto_format"
     },

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -10,6 +10,7 @@ from .autoformat import AnacondaAutoFormat
 from .find_usages import AnacondaFindUsages
 from .enable_linting import AnacondaEnableLinting
 from .next_lint_error import AnacondaNextLintError
+from .prev_lint_error import AnacondaPrevLintError
 from .disable_linting import AnacondaDisableLinting
 from .complete_func_args import AnacondaCompleteFuncargs
 from .set_python_interpreter import AnacondaSetPythonInterpreter
@@ -41,6 +42,7 @@ __all__ = [
     'AnacondaRunLastTest',
     'AnacondaEnableLinting',
     'AnacondaNextLintError',
+    'AnacondaPrevLintError',
     'AnacondaVagrantEnable',
     'AnacondaVagrantStatus',
     'AnacondaVagrantReload',

--- a/commands/prev_lint_error.py
+++ b/commands/prev_lint_error.py
@@ -1,0 +1,72 @@
+
+# Copyright (C) 2013 - Oscar Campos <oscar.campos@member.fsf.org>
+# This program is Free Software see LICENSE file for details
+
+import sublime
+import sublime_plugin
+
+from ..anaconda_lib.helpers import get_settings
+from ..anaconda_lib.helpers import valid_languages
+from ..anaconda_lib.linting.sublime import ANACONDA, update_statusbar
+
+
+class AnacondaPrevLintError(sublime_plugin.WindowCommand):
+    """Jump to the previous lint error on the page
+    """
+
+    def run(self) -> None:
+        self.jump(self._harvest_prev())
+        update_statusbar(self.window.active_view())
+
+    def is_enabled(self) -> bool:
+        """Determines if the command is enabled
+        """
+
+        view = self.window.active_view()
+        if (view.file_name() in ANACONDA['DISABLED']
+                or not get_settings(view, 'anaconda_linting')):
+            return False
+
+        location = view.sel()[0].begin()
+        for lang in valid_languages():
+            matcher = 'source.{}'.format(lang)
+            if view.match_selector(location, matcher) is True:
+                return True
+
+        return False
+
+    def jump(self, lineno: int = None) -> None:
+        """Jump to a line in the view buffer
+        """
+
+        if lineno is None:
+            sublime.status_message('No lint errors')
+            return
+
+        pt = self.window.active_view().text_point(lineno, 0)
+        self.window.active_view().sel().clear()
+        self.window.active_view().sel().add(sublime.Region(pt))
+
+        self.window.active_view().show_at_center(pt)
+
+    def _harvest_prev(self) -> int:
+        """Harvest the prev error that we find and return it back
+        """
+
+        (cur_line, cur_col) = self.window.active_view().rowcol(
+            self.window.active_view().sel()[0].begin()
+        )
+        lines = set([])
+        vid = self.window.active_view().id()
+        for error_type in ['ERRORS', 'WARNINGS', 'VIOLATIONS']:
+            for line, _ in ANACONDA[error_type].get(vid, {}).items():
+                lines.add(int(line))
+
+        lines = sorted(lines)
+        if not len(lines):
+            return None
+
+        if cur_line is not None and lines[0] < cur_line:
+            lines = [l for l in lines if l < cur_line]
+
+        return lines[-1]

--- a/commands/prev_lint_error.py
+++ b/commands/prev_lint_error.py
@@ -69,4 +69,4 @@ class AnacondaPrevLintError(sublime_plugin.WindowCommand):
         if cur_line is not None and lines[0] < cur_line:
             lines = [l for l in lines if l < cur_line]
 
-        return lines[-1]
+        return lines[-1] if len(lines) > 0 else None


### PR DESCRIPTION
I find it especially useful in large files where all or most of the code is written by someone else. Moving back and forth between linting errors makes it easier to understand the style used in that file/project.