### PR TITLE
Jump to assignment if there are no definitions

### DIFF
--- a/anaconda_server/commands/goto.py
+++ b/anaconda_server/commands/goto.py
@@ -18,16 +18,21 @@ class Goto(Command):
         """
 
         try:
-            definitions = self.script.goto_assignments()
-            if all(d.type == 'import' for d in definitions):
-                definitions = self.script.goto_definitions()
+            assignments = self.script.goto_assignments()
+            if all(d.type == 'import' for d in assignments):
+                definitions = filter(lambda x: not x.in_builtin_module(),
+                                     self.script.goto_definitions())
+                if not definitions:
+                    definitions = assignments
+            else:
+                definitions = assignments
         except:
             data = None
             success = False
         else:
             # we use a set here to avoid duplication
             data = set([(i.full_name, i.module_path, i.line, i.column + 1)
-                        for i in definitions if not i.in_builtin_module()])
+                        for i in definitions])
             success = True
 
         self.callback(


### PR DESCRIPTION
Allows to jump to "import" assignment if there are no definitions.
```
file1.py:

SOME_CONST = 0
```
```
file2.py:

from file1 import SOME_CONST
...
print(SOME_CONST)
```
Now one can jump to import assignment from line with `print` statement.