### PR TITLE
Respect indent setting when doing reformat

### DIFF
--- a/anaconda_server/commands/autoformat.py
+++ b/anaconda_server/commands/autoformat.py
@@ -67,6 +67,8 @@ class AutoPep8(Command):
 
         args += ['--max-line-length={0}'.format(
             settings.get('pep8_max_line_length', 79))]
+        args += ['--indent-size={0}'.format(
+            settings.get('tab_size', 4))]
         args += ['anaconda_rocks']
 
         return args

--- a/commands/autoformat.py
+++ b/commands/autoformat.py
@@ -49,7 +49,8 @@ class AnacondaAutoFormat(sublime_plugin.TextCommand):
             ),
             'pep8_max_line_length': get_settings(
                 self.view, 'pep8_max_line_length', 79
-            )
+            ),
+            'tab_size': get_settings(self.view, 'tab_size', 4)
         }
         try:
             messages = {


### PR DESCRIPTION
Previously reformat hard-coded (defaulted to) 4 spaces for indent. This can be useful for everyone using other than 4 spaces indent like us.