### PR TITLE
allow show linting errors inline

### DIFF
--- a/Anaconda.sublime-settings
+++ b/Anaconda.sublime-settings
@@ -291,6 +291,11 @@
     "anaconda_linter_underlines": true,
 
     /*
+        If this is set to true, anaconda will show errors inline.
+    */
+    "anaconda_linter_phantoms": false,
+
+    /*
         If anaconda_linter_show_errors_on_save is set to true, anaconda
         will show a list of errors when you save the file.
 

--- a/Anaconda.sublime-settings
+++ b/Anaconda.sublime-settings
@@ -296,6 +296,16 @@
     "anaconda_linter_phantoms": false,
 
     /*
+        This determines what theme is phantoms used.
+    */
+    "anaconda_linter_phantoms_theme": "phantom",
+
+    /*
+        This determines what template is phantoms used.
+    */
+    "anaconda_linter_phantoms_template": "default",
+
+    /*
         If anaconda_linter_show_errors_on_save is set to true, anaconda
         will show a list of errors when you save the file.
 

--- a/anaconda_lib/phantoms.py
+++ b/anaconda_lib/phantoms.py
@@ -1,0 +1,109 @@
+
+# Copyright (C) 2015 - Oscar Campos <oscar.campos@member.fsf.org>
+# This program is Free Software see LICENSE file for details
+
+import os
+import glob
+import logging
+from string import Template
+
+import sublime
+
+from .helpers import get_settings
+
+
+class Phantom(object):
+    """Just a wrapper around Sublime Text 3 phantoms
+    """
+
+    themes = {}  # type: Dict[str, bytes]
+    templates = {}  # type: Dict[str, str]
+    loaded = False
+    phantomsets = {}
+
+    def __init__(self) -> None:
+        if int(sublime.version()) < 3124:
+            return
+
+        if Phantom.loaded is False:
+            self._load_css_themes()
+            self._load_phantom_templates()
+            Phantom.loaded = True
+
+    def clear_phantoms(self, view):
+        if not self.loaded:
+            return
+
+        vid = view.id()
+        if vid in self.phantomsets:
+            self.phantomsets[vid].update([])
+
+    def update_phantoms(self, view, phantoms):
+        if not self.loaded:
+            return
+
+        thmname = get_settings(view, 'anaconda_linter_phantoms_theme', 'phantom')
+        tplname = get_settings(view, 'anaconda_linter_phantoms_template', 'default')
+
+        thm = self.themes.get(thmname, self.themes['phantom'])
+        tpl = self.templates.get(tplname, self.templates['default'])
+
+        vid = view.id()
+        if vid not in self.phantomsets:
+            self.phantomsets[vid] = sublime.PhantomSet(view, 'Anaconda')
+
+        sublime_phantoms = []
+        for item in phantoms:
+            region = view.full_line(view.text_point(item['line'], 0))
+            context = {'css': thm}
+            context.update(item)
+            content = tpl.safe_substitute(context)
+            sublime_phantoms.append(sublime.Phantom(region, content, sublime.LAYOUT_BLOCK))
+
+        self.phantomsets[vid].update(sublime_phantoms)
+
+    def _load_phantom_templates(self) -> None:
+        """Load phantoms templates from anaconda phantoms templates
+        """
+
+        template_files_pattern = os.path.join(
+            os.path.dirname(__file__), os.pardir,
+            'templates', 'phantoms', '*.tpl')
+        for template_file in glob.glob(template_files_pattern):
+            with open(template_file, 'r', encoding='utf8') as tplfile:
+                tplname = os.path.basename(template_file).split('.tpl')[0]
+                tpldata = '<style>${{css}}</style>{}'.format(tplfile.read())
+                self.templates[tplname] = Template(tpldata)
+
+    def _load_css_themes(self) -> None:
+        """
+        Load any css theme found in the anaconda CSS themes directory
+        or in the User/Anaconda.themes directory
+        """
+
+        css_files_pattern = os.path.join(
+            os.path.dirname(__file__), os.pardir, 'css', '*.css')
+        for css_file in glob.glob(css_files_pattern):
+            logging.info('anaconda: {} css theme loaded'.format(
+                self._load_css(css_file))
+            )
+
+        packages = sublime.active_window().extract_variables()['packages']
+        user_css_path = os.path.join(packages, 'User', 'Anaconda.themes')
+        if os.path.exists(user_css_path):
+            css_files_pattern = os.path.join(user_css_path, '*.css')
+            for css_file in glob.glob(css_files_pattern):
+                logging.info(
+                    'anaconda: {} user css theme loaded',
+                    self._load_css(css_file)
+                )
+
+    def _load_css(self, css_file: str) -> str:
+        """Load a css file
+        """
+
+        theme_name = os.path.basename(css_file).split('.css')[0]
+        with open(css_file, 'r') as resource:
+            self.themes[theme_name] = resource.read()
+
+        return theme_name

--- a/css/phantom.css
+++ b/css/phantom.css
@@ -1,0 +1,19 @@
+html, body { padding: 0; margin: 0; }
+
+.anaconda {
+    background-color: color(var(--background) blend(gray 80%));
+    display: block;
+    padding: 0.2rem;
+}
+
+.anaconda .phantom .errors {
+    color: red;
+}
+
+.anaconda .phantom .warnings {
+    color: orange;
+}
+
+.anaconda .phantom .violations {
+    color: blue;
+}

--- a/templates/phantoms/default.tpl
+++ b/templates/phantoms/default.tpl
@@ -1,0 +1,5 @@
+<div class="anaconda">
+    <div class="phantom">
+        <pre class="${level}">${messages}</pre>
+    </div>
+</div>


### PR DESCRIPTION
Sublime Text 3 Build 3124 introduced the [Phantoms](http://www.sublimetext.com/docs/3/api_reference.html#sublime.Phantom) API, allows HTML annotations to be added to the text buffer by plugins.
This PR allow show linting errors inline using this new API, also adding a new setting `anaconda_linter_phantoms` to turn on this feature (default off).
![image](https://cloud.githubusercontent.com/assets/1702313/23503763/f42ea654-ff77-11e6-8c47-9a4f525c47b2.png)
