### PR TITLE
Fix two typos in default settings

### DIFF
--- a/Anaconda.sublime-settings
+++ b/Anaconda.sublime-settings
@@ -666,7 +666,7 @@
 
     /*
         If this is set to true, anaconda will unload plugins that
-        make it malfunction intefering with it
+        make it malfunction interfering with it
     */
     "auto_unload_conflictive_plugins": true
 }

--- a/Anaconda.sublime-settings
+++ b/Anaconda.sublime-settings
@@ -665,7 +665,7 @@
 	"swallow_startup_errors": false,
 
     /*
-        If this is set to true, anaconda will uload plugins that
+        If this is set to true, anaconda will unload plugins that
         make it malfunction intefering with it
     */
     "auto_unload_conflictive_plugins": true


### PR DESCRIPTION
Fixed what I assume is a typo in the default settings comments