### PR TITLE
Fix Base URL not HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 
 
 
-    <base href="http://damnwidget.github.io/anaconda">
+    <base href="https://damnwidget.github.io/anaconda">
     <title>Anaconda, the Python IDE for Sublime Text 3</title>
     <link rel="canonical" href="http://damnwidget.github.io/anaconda/">
     <link href="http://damnwidget.github.io/anaconda/index.xml" rel="alternate" type="application/rss+xml" title="Anaconda, the Python IDE for Sublime Text 3" />


### PR DESCRIPTION
Fix HTTPS views of this page.

Page renders are incomplete due to Chrome not loading mixed contents. See screenshot below for a demonstration:

![Screenshot of page with https](https://i.imgur.com/HdKmZLL.png)
![Mixed content warnings](https://i.imgur.com/2lYW55M.png)