### PR TITLE
Fix mypy version parsing for hashed versions

### DIFF
--- a/anaconda_lib/linting/anaconda_mypy.py
+++ b/anaconda_lib/linting/anaconda_mypy.py
@@ -20,7 +20,7 @@ try:
     from mypy import main as mypy
     MYPY_SUPPORTED = True
     MYPY_VERSION = tuple(
-      int(i) for i in mypy.__version__.replace('-dev', '').split('.')
+        int(i) for i in mypy.__version__.split('-dev')[0].split('.')
     )
     del mypy
 except ImportError:


### PR DESCRIPTION
I have installed mypy from its git repo and it made jsonserver.py crash:

```bash
...
  File "anaconda_lib\linting\anaconda_mypy.py", line 23, in <genexpr>
    int(i) for i in mypy.__version__.replace('-dev', '').split('.')
ValueError: invalid literal for int() with base 10: '520-ad32dec25fd956a3279dba0b2dcd0cad2d12fb4d'
```

The reason is `__version__` had hash in it:
```python
>>> from mypy import main
>>> main.__version__
'0.520-dev-ad32dec25fd956a3279dba0b2dcd0cad2d12fb4d'
```

This fixes it and still works for normal-looking versions (`12.34`, `12.34-dev`)