### PR TITLE
fix for disable_linting appending without check

### DIFF
--- a/commands/disable_linting.py
+++ b/commands/disable_linting.py
@@ -15,20 +15,23 @@ class AnacondaDisableLinting(sublime_plugin.WindowCommand):
 
     def run(self) -> None:
         view = self.window.active_view()
-        if view.file_name() is not None:
-            ANACONDA['DISABLED'].append(view.file_name())
-        else:
-            ANACONDA['DISABLED_BUFFERS'].append((self.window.id(), view.id()))
-
-        erase_lint_marks(view)
+        window_view = (self.window.id(), view.id())
+        filename = view.file_name()
+        if filename is not None and filename not in ANACONDA['DISABLED']:
+            ANACONDA['DISABLED'].append(filename)
+            erase_lint_marks(view)
+        elif filename is None and window_view not in ANACONDA['DISABLED_BUFFERS']:
+            ANACONDA['DISABLED_BUFFERS'].append(window_view)
+            erase_lint_marks(view)
 
     def is_enabled(self) -> bool:
         """Determines if the command is enabled
         """
 
         view = self.window.active_view()
+        window_view = (self.window.id(), view.id())
         if ((view.file_name() in ANACONDA['DISABLED']
-                and view.id() in ANACONDA['DISABLED_BUFFERS'])
+                and window_view in ANACONDA['DISABLED_BUFFERS'])
                 or not get_settings(view, 'anaconda_linting')):
             return False
 

--- a/commands/enable_linting.py
+++ b/commands/enable_linting.py
@@ -19,10 +19,10 @@ class AnacondaEnableLinting(sublime_plugin.WindowCommand):
         filename = view.file_name()
         if filename is not None and filename in ANACONDA['DISABLED']:
             ANACONDA['DISABLED'].remove(filename)
+            run_linter(view)
         elif filename is None and window_view in ANACONDA['DISABLED_BUFFERS']:
             ANACONDA['DISABLED_BUFFERS'].remove(window_view)
-
-        run_linter(self.window.active_view())
+            run_linter(view)
 
     def is_enabled(self) -> bool:
         """Determines if the command is enabled


### PR DESCRIPTION
1. When running the disable_linting command multiple times, filename or
window_view gets appended to the
ANACONDA['DISABLED']/ANACONDA['DISABLED_BUFFERS'] even if it's already
there.
The user then has to run the enable_linting command the same number of
times to enable it again.

2. is_enabled looked for view.id() instead of (self.window.id(), view.id()).

Also I made the two files look more unified.
