### PR TITLE
Fix "'tmp' referenced before assignment" error

### DIFF
--- a/anaconda_lib/helpers.py
+++ b/anaconda_lib/helpers.py
@@ -266,6 +266,7 @@ def expand(view, path):
     """
 
     window = view.window()
+    tmp = path
     if window is not None:
         tmp = sublime.expand_variables(path, window.extract_variables())
         tmp = os.path.expanduser(os.path.expandvars(tmp))


### PR DESCRIPTION
```python
  File "/Users/alin/Library/Application Support/Sublime Text 3/Packages/Anaconda/anaconda_lib/helpers.py", line 273, in expand
    return tmp
UnboundLocalError: local variable 'tmp' referenced before assignment
```