### PR TITLE
Allow multiple .anaconda files in a single project

### DIFF
--- a/Anaconda.sublime-settings
+++ b/Anaconda.sublime-settings
@@ -682,7 +682,14 @@
         If this is set to true, anaconda will unload plugins that
         make it malfunction interfering with it
     */
-    "auto_unload_conflictive_plugins": true
+    "auto_unload_conflictive_plugins": true,
+    /*
+        If this is set to true, anaconda will search for environment hook
+        files in any directory level down to the one the current file is in
+        as opposed to the default where it will only search down to the
+        root of your working directory.
+    */
+    "anaconda_allow_project_environment_hooks": false
 }
 
 // vim: set ft=javascript:

--- a/anaconda_lib/helpers.py
+++ b/anaconda_lib/helpers.py
@@ -208,7 +208,7 @@ def get_settings(view, name, default=None):
     if (name in ('python_interpreter', 'extra_paths') and not
             ENVIRON_HOOK_INVALID[view.id()]):
         if view.window() is not None and view.window().folders():
-            dirname = view.window().folders()[0]
+            dirname = os.path.dirname(view.file_name())
             while True:
                 environfile = os.path.join(dirname, '.anaconda')
                 if os.path.exists(environfile) and os.path.isfile(environfile):

--- a/anaconda_lib/helpers.py
+++ b/anaconda_lib/helpers.py
@@ -220,7 +220,7 @@ def get_settings(view, name, default=None):
             while True:
                 environfile = os.path.join(dirname, '.anaconda')
                 if os.path.exists(environfile) and os.path.isfile(environfile):
-                    print("Environ found on %s" % environfile)
+                    # print("Environ found on %s" % environfile)
                     with open(environfile, 'r') as jsonfile:
                         try:
                             data = json.loads(jsonfile.read())

--- a/anaconda_lib/helpers.py
+++ b/anaconda_lib/helpers.py
@@ -208,11 +208,19 @@ def get_settings(view, name, default=None):
     if (name in ('python_interpreter', 'extra_paths') and not
             ENVIRON_HOOK_INVALID[view.id()]):
         if view.window() is not None and view.window().folders():
-            dirname = os.path.dirname(view.file_name())
+            allow_multiple_env_hooks = get_settings(
+                view,
+                'anaconda_allow_project_environment_hooks',
+                False
+            )
+            if allow_multiple_env_hooks:
+                dirname = os.path.dirname(view.file_name())
+            else:
+                dirname = view.window().folders()[0]
             while True:
                 environfile = os.path.join(dirname, '.anaconda')
                 if os.path.exists(environfile) and os.path.isfile(environfile):
-                    # print("Environ found on %s" % environfile)
+                    print("Environ found on %s" % environfile)
                     with open(environfile, 'r') as jsonfile:
                         try:
                             data = json.loads(jsonfile.read())


### PR DESCRIPTION
Use case:

Working in a monorepo with multiple python projects. Each project has its own virtualenv. This allows me to have a single `.anaconda` file in each of the python projects, but only using a single sublime project.

This should not break the current behavior in any way, only expand to it.