### PR TITLE
Fix mypy setting mypy_silent_imports and mypy_almost_silent

### DIFF
--- a/anaconda_lib/linting/sublime.py
+++ b/anaconda_lib/linting/sublime.py
@@ -388,9 +388,10 @@ def get_mypy_settings(view):
 
     mypy_settings = []
     if get_settings(view, 'mypy_silent_imports', False):
-        mypy_settings.append('--silent-imports')
+        mypy_settings.append('--ignore-missing-imports')
+        mypy_settings.append('--follow-imports=skip') 
     if get_settings(view, 'mypy_almost_silent', False):
-        mypy_settings.append('--almost-silent')
+        mypy_settings.append('--follow-imports=error')
     if get_settings(view, 'mypy_py2', False):
         mypy_settings.append('--py2')
     if get_settings(view, 'mypy_disallow_untyped_calls', False):


### PR DESCRIPTION
When setting `mypy_silent_imports` or `mypy_almost_silent`, linting with mypy will stop working altogether.

The following flags of mypy have been deprecated in version 0.6 and will result in warnings, which somehow prevent Anaconda Sublime from receiving linting outputs:

```
mypy --silent-imports
Warning: --silent-imports has been replaced by --ignore-missing-imports --follow-imports=skip

mypy --almost-silent
Warning: --almost-silent has been replaced by --follow-imports=errors

mypy --follow-imports=errors
mypy: error: argument --follow-imports: invalid choice: 'errors' (choose from 'normal', 'silent', 'skip', 'error')
```