### PR TITLE
Add new setting 'socket_timeout' for slow jsonserver/jsonclient connect

### DIFF
--- a/anaconda_lib/helpers.py
+++ b/anaconda_lib/helpers.py
@@ -380,6 +380,17 @@ def get_window_view(vid):
             return view
 
 
+def get_socket_timeout(default):
+    """
+    Some systems with weird enterprise security stuff can take a while
+    to return a socket - permit overrides to default timeouts. Same thing
+    occurs with certain other sublime plugins added. This lets the user
+    set a timeout appropriate to their system without swallowing all
+    startup errors
+    """
+    return get_settings(active_view(), 'socket_timeout', default)
+
+
 def cache(func):
     """
     Stupid and simplistic cache system that caches results from functions

--- a/anaconda_lib/workers/local_worker.py
+++ b/anaconda_lib/workers/local_worker.py
@@ -8,7 +8,7 @@ import sublime
 
 from ..logger import Log
 from .worker import Worker
-from ..helpers import project_name
+from ..helpers import project_name, get_socket_timeout
 from ..constants import WorkerStatus
 from ..builder.python_builder import AnacondaSetPythonBuilder
 
@@ -30,10 +30,11 @@ class LocalWorker(Worker):
             self.tip = self.process.tip
             return False
 
+        timeout = get_socket_timeout(0.2)
         start = time.time()
         times = 1
-        interval = 2
-        while not self._status(0.20):
+        interval = timeout * 10
+        while not self._status(timeout):
             if time.time() - start >= interval:  # expressed in seconds
                 msg = '{}. tried to connect {} times during {} seconds'
                 self.error = msg.format(self.error, times, interval)


### PR DESCRIPTION
Permits user to define a longer timeout (e.g 0.5) without swallowing all errors and having potential silent fails in future