### PR TITLE
Change replace variables order

### DIFF
--- a/anaconda_lib/helpers.py
+++ b/anaconda_lib/helpers.py
@@ -275,8 +275,8 @@ def expand(view, path):
 
     window = view.window()
     if window is not None:
-        tmp = sublime.expand_variables(path, window.extract_variables())
-        tmp = os.path.expanduser(os.path.expandvars(tmp))
+        tmp = os.path.expanduser(os.path.expandvars(path))
+        tmp = sublime.expand_variables(tmp, window.extract_variables())
     else:
         return path
 


### PR DESCRIPTION
Fix the issue #517.

The problem is: If we try to run the `sublime.expand_variables` first, it will remove variables not found in `window.extract_variables()`. So when the code reaches the next line, the variable that exists in `os.environ` will not be replaced.

Example:
```
>>> path = '$VIRTUAL_ENV/bin/python'
>>> sublime.expand_variables(path, window.extract_variables())
'/bin/python'
```

With this fix, running `os.path.expanduser(os.path.expandvars(path))` first, will replace the `os.environ` variables, and it will **KEEP** variables that is not present. So when it reaches the next line, it will be able to replace any more window variables.

Example:
```
>>> window.extract_variables()
{'file_base_name': 'helpers'}
>>> os.environ
environ({'VIRTUAL_ENV': 'my_virtual_env_path'})
>>> path = '$VIRTUAL_ENV/text/$file_base_name'
>>> tmp = os.path.expanduser(os.path.expandvars(path))
>>> sublime.expand_variables(tmp, window.extract_variables())
'my_virtual_env_path/text/helpers'
```
