### PR TITLE
WSL 1903 fix for socketfile creation

### DIFF
--- a/anaconda_server/jsonserver.py
+++ b/anaconda_server/jsonserver.py
@@ -154,6 +154,9 @@ class JSONServer(asyncore.dispatcher):
         self.last_call = time.time()
 
         self.bind(self.address)
+        if address_family == socket.AF_UNIX:
+            # WSL 1903 fix
+            os.chmod(self.address, 0o600)
         logging.debug('bind: address=%s' % (address,))
         self.listen(self.request_queue_size)
         logging.debug('listen: backlog=%d' % (self.request_queue_size,))


### PR DESCRIPTION
Hey,

on the latest windows WSL (update 1903), the created socket file gets a 0o000 permission regardless of the current umask. I managed to reproduce it in Python and this seems to be the fix for it.

Also might be related to https://github.com/Microsoft/WSL/issues/352