### PR TITLE
Fix AttributeError

### DIFF
--- a/commands/set_python_interpreter.py
+++ b/commands/set_python_interpreter.py
@@ -59,7 +59,7 @@ class AnacondaSetPythonInterpreter(sublime_plugin.TextCommand):
 
     def get_project_data(self) -> Dict[str, Any]:
         """Return the project data for the current window"""
-        return sublime.active_window().project_data()
+        return sublime.active_window().project_data() or {}
 
     def get_current_interpreter_path(self) -> str:
         """Returns the current path from the settings if possible"""


### PR DESCRIPTION
Fixes raised AttributeError when sublime.active_window().project_data() returns None instead of an empty dict. Fixes case where there is no currently loaded project (e.g., just open a test.py file and want to change the anaconda interpreter without creating a new project).