### PR TITLE
Silence mypy followed imports

### DIFF
--- a/anaconda_lib/linting/anaconda_mypy.py
+++ b/anaconda_lib/linting/anaconda_mypy.py
@@ -81,8 +81,10 @@ class MyPy(object):
         if MyPy.VERSION < (0, 4, 5):
             err_ctx = '--suppress-error-context'
 
-        args = shlex.split('\'{0}\' -O -m mypy {1} {2} {3} \'{4}\''.format(
-            sys.executable, err_sum, err_ctx,
+        dont_follow_imports = "--follow-imports silent"
+
+        args = shlex.split('\'{0}\' -O -m mypy {1} {2} {3} {4} \'{5}\''.format(
+            sys.executable, err_sum, err_ctx, dont_follow_imports,
             ' '.join(self.settings[:-1]), self.filename)
         )
         env = os.environ.copy()


### PR DESCRIPTION
Currently mypy will follow imports in files and return all errors in these imported files.  This adds the `follow-imports silent` flag to mypy so that only results relevant to the current file are returned.

Should resolve https://github.com/DamnWidget/anaconda/issues/809