### PR TITLE
Adds linting messages on line hover to anaconda. Resolves #862

### DIFF
--- a/Anaconda.sublime-settings
+++ b/Anaconda.sublime-settings
@@ -320,6 +320,11 @@
     "anaconda_linter_phantoms_template": "default",
 
     /*
+        This determines whether error messages are show when hovering over a line.
+    */
+    "anaconda_linter_hover_message": false,
+
+    /*
         If anaconda_linter_show_errors_on_save is set to true, anaconda
         will show a list of errors when you save the file.
 

--- a/anaconda_lib/linting/sublime.py
+++ b/anaconda_lib/linting/sublime.py
@@ -330,6 +330,35 @@ def get_lineno_msgs(view, lineno):
     return errors_msg
 
 
+def get_specific_lineno_msgs(view, lineno):
+    """Get lineno error messages and return them by message type
+    """
+
+    ERRORS = ANACONDA.get('ERRORS')
+    WARNINGS = ANACONDA.get('WARNINGS')
+    VIOLATIONS = ANACONDA.get('VIOLATIONS')
+
+    specific_errors_msg = {}
+
+    if lineno is not None:
+        def check_and_delete_if_empty(dct: dict, key: str):
+            if not dct.get(key):
+                del dct[key]
+
+        vid = view.id()
+        if vid in ERRORS:
+            specific_errors_msg['ERRORS'] = ERRORS[vid].get(lineno, [])
+            check_and_delete_if_empty(specific_errors_msg, 'ERRORS')
+        if vid in WARNINGS:
+            specific_errors_msg['WARNINGS'] = WARNINGS[vid].get(lineno, [])
+            check_and_delete_if_empty(specific_errors_msg, 'WARNINGS')
+        if vid in VIOLATIONS:
+            specific_errors_msg['VIOLATIONS'] = VIOLATIONS[vid].get(lineno, [])
+            check_and_delete_if_empty(specific_errors_msg, 'VIOLATIONS')
+
+    return specific_errors_msg
+
+
 def run_linter(view=None, hook=None):
     """Run the linter for the given view
     """

--- a/css/popup.css
+++ b/css/popup.css
@@ -19,3 +19,15 @@ div.anaconda {
     font-weight: bold;
     font-size: 1.05em;
 }
+
+.anaconda .error_warning .errors {
+    color: red;
+}
+
+.anaconda .error_warning .warnings {
+    color: orange;
+}
+
+.anaconda .error_warning .violations {
+    color: blue;
+}

--- a/templates/tooltips/error_warning.tpl
+++ b/templates/tooltips/error_warning.tpl
@@ -1,0 +1,5 @@
+<div class="anaconda">
+    <div class="error_warning">
+        ${helper_content}
+    </div>
+</div>

--- a/templates/tooltips/error_warning_helper.tpl
+++ b/templates/tooltips/error_warning_helper.tpl
@@ -1,0 +1,1 @@
+<pre class="${level}">${messages}</pre>


### PR DESCRIPTION
	* Added on_hover listener to show a popup if a line contains a linting messages
	* Added "anaconda_linter_hover_message" to Anaconda.sublime-settings. Defaults to false.
Hi, this is my pull request for #862 . I know the contributing guide says to wait for the issue to be discussed, but I'm kinda impatient and I wanted this enhancement to be out there for others who want the feature. 

Since this is a GUI feature, I didn't add any tests. Tell me if this should be fixed.
This is the first Sublime plugin I'm working on, and I added some comments(questions) in the code, any assistance would be appreciated.

Fixes #862 