### PR TITLE
Fix invalid syntax in help message output, mentioned in #850

### DIFF
--- a/anaconda_lib/workers/local_worker.py
+++ b/anaconda_lib/workers/local_worker.py
@@ -119,7 +119,7 @@ class LocalWorker(Worker):
             'jsonserver.py script running in your system. If there is, check '
             '{} writing the following script in your Sublime Text 3 console:'
             '\n\nimport socket; socket.socket(socket.{}, '
-            'socket.SOCK_STREAM).connect("{}")\n\nIf anaconda works just fine '
+            'socket.SOCK_STREAM).connect({})\n\nIf anaconda works just fine '
             'after you received this error and the command above worked you '
             'can make anaconda to do not show you this error anymore setting '
             'the \'swallow_startup_errors\' to \'true\' in your '


### PR DESCRIPTION
https://github.com/DamnWidget/anaconda/issues/850#issuecomment-681808398

I too hit the invalid code example while quickly copying and pasting:

```python
In [1]: import socket; socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect("("localhost", 59199)")
  File "<ipython-input-1-cb7c2f46ddd7>", line 1
    import socket; socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect("("localhost", 59199)")
                                                                                ^
SyntaxError: invalid syntax

```

Fixed it since I had a couple minutes.