### PR TITLE
local_worker: Increase timeout for get_socket_timeout() call.

### DIFF
--- a/anaconda_lib/workers/local_worker.py
+++ b/anaconda_lib/workers/local_worker.py
@@ -31,7 +31,7 @@ class LocalWorker(Worker):
             self.tip = self.process.tip
             return False
 
-        timeout = get_socket_timeout(0.2)
+        timeout = get_socket_timeout(0.5)
         start = time.time()
         times = 1
         interval = timeout * 10


### PR DESCRIPTION
Increase the timeout for he get_socket_timeout() call as suggeted in 
https://stackoverflow.com/questions/41849999/sublime-text-3-anaconda-package-error-connection-to-localhost-timed-out

See problem description in the above URL.

This change fixes this issue which is persistent on MacOS Big Sur with Sublime Text build 4113.