### PR TITLE
Use the edit_settings command

### DIFF
--- a/templates/Main.sublime-menu.tpl
+++ b/templates/Main.sublime-menu.tpl
@@ -26,14 +26,12 @@
                             },
                             { "caption": "-" },
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/$package_folder/Anaconda.sublime-settings"},
-                                "caption": "Settings - Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/Anaconda.sublime-settings"},
-                                "caption": "Settings – User"
+                                "caption": "Preferences: Settings",
+                                "command": "edit_settings", "args":
+                                {
+                                    "base_file": "${packages}/$package_folder/Anaconda.sublime-settings",
+                                    "default": "{\n\t$0\n}\n"
+                                }
                             },
                             {
                                 "command": "open_file_settings",
@@ -41,52 +39,12 @@
                             },
                             { "caption": "-" },
                             {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/$package_folder/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/$package_folder/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/$package_folder/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
-                                    "platform": "OSX"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
-                                    "platform": "Linux"
-                                },
-                                "caption": "Key Bindings – User"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {
-                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
-                                    "platform": "Windows"
-                                },
-                                "caption": "Key Bindings – User"
+                                "caption": "Preferences: Key Bindings",
+                                "command": "edit_settings", "args":
+                                {
+                                    "base_file": "${packages}/$package_folder/Default ($platform).sublime-keymap",
+                                    "default": "[\n\t$0\n]\n"
+                                }
                             },
                             { "caption": "-" }
                         ]


### PR DESCRIPTION
Uses the edit_settings command provided by sublime to open the default and user settings in the same window.